### PR TITLE
Add operators

### DIFF
--- a/src/command_handler.rs
+++ b/src/command_handler.rs
@@ -28,6 +28,18 @@ pub fn is_default_function(func_name: &str) -> bool {
             | "dec"
             | "decimal"
             | "int"
+            | "Number.EqualTo"
+            | "Number.NotEqualTo"
+            | "String.EqualTo"
+            | "String.NotEqualTo"
+            | "Boolean.EqualTo"
+            | "Boolean.NotEqualTo"
+            | "Number.GreaterThan"
+            | "Number.LessThan"
+            | "Number.Add"
+            | "Number.Subtract"
+            | "Number.Multiply"
+            | "Number.Divide"
     )
 }
 
@@ -55,6 +67,34 @@ fn handle_known_default_function(func_data: &FuncData) -> Result<YarnValue, Func
                 found: crate::type_names::STR,
             }),
             YarnValue::F32(v) => Ok(*v),
+        }
+    }
+
+    fn extract_str(param: &YarnValue) -> Result<&str, FuncError> {
+        match param {
+            YarnValue::Bool(_) => Err(FuncError::UnexpectedParamType {
+                expected: crate::type_names::STR,
+                found: crate::type_names::BOOL,
+            }),
+            YarnValue::Str(v) => Ok(v),
+            YarnValue::F32(_) => Err(FuncError::UnexpectedParamType {
+                expected: crate::type_names::STR,
+                found: crate::type_names::F32,
+            }),
+        }
+    }
+
+    fn extract_bool(param: &YarnValue) -> Result<bool, FuncError> {
+        match param {
+            YarnValue::Bool(v) => Ok(*v),
+            YarnValue::Str(_) => Err(FuncError::UnexpectedParamType {
+                expected: crate::type_names::BOOL,
+                found: crate::type_names::STR,
+            }),
+            YarnValue::F32(_) => Err(FuncError::UnexpectedParamType {
+                expected: crate::type_names::BOOL,
+                found: crate::type_names::F32,
+            }),
         }
     }
 
@@ -163,6 +203,90 @@ fn handle_known_default_function(func_data: &FuncData) -> Result<YarnValue, Func
 
             Ok(YarnValue::F32(num.floor()))
         }
+        "Number.EqualTo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[0])?;
+            let b = extract_f32(&func_data.parameters[1])?;
+
+            Ok(YarnValue::Bool(a == b))
+        },
+        "Number.NotEqualTo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[0])?;
+            let b = extract_f32(&func_data.parameters[1])?;
+
+            Ok(YarnValue::Bool(a != b))
+        },
+        "String.EqualTo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_str(&func_data.parameters[0])?;
+            let b = extract_str(&func_data.parameters[1])?;
+
+            Ok(YarnValue::Bool(a == b))
+        },
+        "String.NotEqualTo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_str(&func_data.parameters[0])?;
+            let b = extract_str(&func_data.parameters[1])?;
+
+            Ok(YarnValue::Bool(a != b))
+        },
+        "Boolean.EqualTo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_bool(&func_data.parameters[0])?;
+            let b = extract_bool(&func_data.parameters[1])?;
+
+            Ok(YarnValue::Bool(a == b))
+        },
+        "Boolean.NotEqualTo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_bool(&func_data.parameters[0])?;
+            let b = extract_bool(&func_data.parameters[1])?;
+
+            Ok(YarnValue::Bool(a != b))
+        },
+        "Number.GreaterThan" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[0])?;
+            let b = extract_f32(&func_data.parameters[1])?;
+
+            Ok(YarnValue::Bool(a > b))
+        },
+        "Number.LessThan" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[0])?;
+            let b = extract_f32(&func_data.parameters[1])?;
+
+            Ok(YarnValue::Bool(a < b))
+        },
+        "Number.Add" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[0])?;
+            let b = extract_f32(&func_data.parameters[1])?;
+
+            Ok(YarnValue::F32(a + b))
+        },
+        "Number.Subtract" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[0])?;
+            let b = extract_f32(&func_data.parameters[1])?;
+
+            Ok(YarnValue::F32(a - b))
+        },
+        "Number.Multiply" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[0])?;
+            let b = extract_f32(&func_data.parameters[1])?;
+
+            Ok(YarnValue::F32(a * b))
+        },
+        "Number.Divide" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[0])?;
+            let b = extract_f32(&func_data.parameters[1])?;
+
+            Ok(YarnValue::F32(a / b))
+        },
         _ => unreachable!(),
     }
 }

--- a/src/command_handler.rs
+++ b/src/command_handler.rs
@@ -32,14 +32,21 @@ pub fn is_default_function(func_name: &str) -> bool {
             | "Number.NotEqualTo"
             | "String.EqualTo"
             | "String.NotEqualTo"
-            | "Boolean.EqualTo"
-            | "Boolean.NotEqualTo"
+            | "Bool.EqualTo"
+            | "Bool.NotEqualTo"
             | "Number.GreaterThan"
             | "Number.LessThan"
+            | "Number.GreaterThanOrEqualTo"
+            | "Number.LessThanOrEqualTo"
+            | "Bool.Or"
+            | "Bool.And"
+            | "Bool.Xor"
+            | "Bool.Not"
             | "Number.Add"
-            | "Number.Subtract"
+            | "Number.Minus"
             | "Number.Multiply"
             | "Number.Divide"
+            | "Number.Modulo"
     )
 }
 
@@ -205,87 +212,135 @@ fn handle_known_default_function(func_data: &FuncData) -> Result<YarnValue, Func
         }
         "Number.EqualTo" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_f32(&func_data.parameters[0])?;
-            let b = extract_f32(&func_data.parameters[1])?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
 
             Ok(YarnValue::Bool(a == b))
         },
         "Number.NotEqualTo" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_f32(&func_data.parameters[0])?;
-            let b = extract_f32(&func_data.parameters[1])?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
 
             Ok(YarnValue::Bool(a != b))
         },
         "String.EqualTo" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_str(&func_data.parameters[0])?;
-            let b = extract_str(&func_data.parameters[1])?;
+            let a = extract_str(&func_data.parameters[1])?;
+            let b = extract_str(&func_data.parameters[0])?;
 
             Ok(YarnValue::Bool(a == b))
         },
         "String.NotEqualTo" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_str(&func_data.parameters[0])?;
-            let b = extract_str(&func_data.parameters[1])?;
+            let a = extract_str(&func_data.parameters[1])?;
+            let b = extract_str(&func_data.parameters[0])?;
 
             Ok(YarnValue::Bool(a != b))
         },
-        "Boolean.EqualTo" => {
+        "Bool.EqualTo" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_bool(&func_data.parameters[0])?;
-            let b = extract_bool(&func_data.parameters[1])?;
+            let a = extract_bool(&func_data.parameters[1])?;
+            let b = extract_bool(&func_data.parameters[0])?;
 
             Ok(YarnValue::Bool(a == b))
         },
-        "Boolean.NotEqualTo" => {
+        "Bool.NotEqualTo" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_bool(&func_data.parameters[0])?;
-            let b = extract_bool(&func_data.parameters[1])?;
+            let a = extract_bool(&func_data.parameters[1])?;
+            let b = extract_bool(&func_data.parameters[0])?;
 
             Ok(YarnValue::Bool(a != b))
         },
         "Number.GreaterThan" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_f32(&func_data.parameters[0])?;
-            let b = extract_f32(&func_data.parameters[1])?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
 
             Ok(YarnValue::Bool(a > b))
         },
         "Number.LessThan" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_f32(&func_data.parameters[0])?;
-            let b = extract_f32(&func_data.parameters[1])?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
 
             Ok(YarnValue::Bool(a < b))
         },
+        "Number.GreaterThanOrEqualTo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
+
+            Ok(YarnValue::Bool(a >= b))
+        },
+        "Number.LessThanOrEqualTo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
+
+            Ok(YarnValue::Bool(a <= b))
+        },
+        "Bool.Or" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_bool(&func_data.parameters[1])?;
+            let b = extract_bool(&func_data.parameters[0])?;
+
+            Ok(YarnValue::Bool(a || b))
+        },
+        "Bool.And" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_bool(&func_data.parameters[1])?;
+            let b = extract_bool(&func_data.parameters[0])?;
+
+            Ok(YarnValue::Bool(a && b))
+        },
+        "Bool.Xor" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_bool(&func_data.parameters[1])?;
+            let b = extract_bool(&func_data.parameters[0])?;
+
+            Ok(YarnValue::Bool(a ^ b))
+        },
+        "Bool.Not" => {
+            param_count_is(&func_data.parameters, 1)?;
+            let a = extract_bool(&func_data.parameters[0])?;
+
+            Ok(YarnValue::Bool(!a))
+        },
         "Number.Add" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_f32(&func_data.parameters[0])?;
-            let b = extract_f32(&func_data.parameters[1])?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
 
             Ok(YarnValue::F32(a + b))
         },
-        "Number.Subtract" => {
+        "Number.Minus" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_f32(&func_data.parameters[0])?;
-            let b = extract_f32(&func_data.parameters[1])?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
 
             Ok(YarnValue::F32(a - b))
         },
         "Number.Multiply" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_f32(&func_data.parameters[0])?;
-            let b = extract_f32(&func_data.parameters[1])?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
 
             Ok(YarnValue::F32(a * b))
         },
         "Number.Divide" => {
             param_count_is(&func_data.parameters, 2)?;
-            let a = extract_f32(&func_data.parameters[0])?;
-            let b = extract_f32(&func_data.parameters[1])?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
 
             Ok(YarnValue::F32(a / b))
+        },
+        "Number.Modulo" => {
+            param_count_is(&func_data.parameters, 2)?;
+            let a = extract_f32(&func_data.parameters[1])?;
+            let b = extract_f32(&func_data.parameters[0])?;
+
+            Ok(YarnValue::F32(a % b))
         },
         _ => unreachable!(),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl YarnRunner {
                 }
                 Instruction::JumpIfFalse(node_name) => {
                     let stack_top = state.stack.last().expect("is this possible?");
-                    if stack_top.try_to_bool()? {
+                    if !stack_top.try_to_bool()? {
                         state.instruction = *node
                             .jump_table
                             .get(node_name)


### PR DESCRIPTION
Hey, thank you so much for creating this wonderful plugin. I am doing a dialogue-based game in bevy for a game jam and this is everything I could have asked for, since other yarn-spinner libraries I tried are not up to date. I noticed there was no support still for operations on variables (equality, comparison and math), so I went ahead and added them, I hope it is ok with you. I tried to follow the style of the other functions on `handle_known_default_functions`. Thank you again, your library is beyond awesome!

New functions added:

```
Number.EqualTo
Number.NotEqualTo
String.EqualTo
String.NotEqualTo
Bool.EqualTo
Bool.NotEqualTo
Number.GreaterThan
Number.LessThan
Number.GreaterThanOrEqualTo
Number.LessThanOrEqualTo
Bool.Or
Bool.And
Bool.Xor
Bool.Not
Number.Add
Number.Minus
Number.Multiply
Number.Divide
Number.Modulo
```

Now you can do:

```
<<if $var == "value">>
    <<set $num = $num + 10>>
<<elseif $num > 10>>
    The value of a*b is {$a * $b}
<<endif>>
```